### PR TITLE
QueryRegistrar Extended, ICacheQuery Interface

### DIFF
--- a/EFCache/AlwaysCachedQueriesRegistrar.cs
+++ b/EFCache/AlwaysCachedQueriesRegistrar.cs
@@ -8,7 +8,7 @@ namespace EFCache
     {
         public static readonly AlwaysCachedQueriesRegistrar Instance = new AlwaysCachedQueriesRegistrar();
 
-        private readonly QueryRegistrar _cachedQueries = new QueryRegistrar();
+        private ICacheQuery _cachedQueries => CacheConfiguration.Instance.CacheQuery;
 
         private AlwaysCachedQueriesRegistrar()
         {

--- a/EFCache/BlacklistedQueriesRegistrar.cs
+++ b/EFCache/BlacklistedQueriesRegistrar.cs
@@ -8,7 +8,7 @@ namespace EFCache
     {
         public static readonly BlacklistedQueriesRegistrar Instance = new BlacklistedQueriesRegistrar();
 
-        private readonly QueryRegistrar _blacklistedQueries = new QueryRegistrar();
+        private ICacheQuery _blacklistedQueries => CacheConfiguration.Instance.CacheQuery;
 
         private BlacklistedQueriesRegistrar()
         {

--- a/EFCache/CacheConfiguration.cs
+++ b/EFCache/CacheConfiguration.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EFCache
+{
+    public static class CacheConfiguration
+    {
+        private static ICache _instance;
+        public static ICache Instance
+        {
+            get { return _instance; }
+        }
+
+        static CacheConfiguration()
+        {
+            _instance = new InMemoryCache();
+        }
+
+        public static void ReplaceCache<TCache>()
+            where TCache : ICache
+        {
+            _instance = Activator.CreateInstance<TCache>() as ICache;
+        }
+
+        public static void ReplaceCache<TCache>(TCache cache)
+            where TCache : ICache
+        {
+            _instance = Activator.CreateInstance(cache.GetType()) as ICache;
+        }
+    }
+}

--- a/EFCache/CacheTransactionHandler.cs
+++ b/EFCache/CacheTransactionHandler.cs
@@ -12,18 +12,13 @@ namespace EFCache
 
     public class CacheTransactionHandler : IDbTransactionInterceptor
     {
-        private readonly ConcurrentDictionary<DbTransaction, List<string>> _affectedSetsInTransaction 
+        private readonly ConcurrentDictionary<DbTransaction, List<string>> _affectedSetsInTransaction
             = new ConcurrentDictionary<DbTransaction, List<string>>();
-        private readonly ICache _cache;
 
-        public CacheTransactionHandler(ICache cache)
+        private ICache _cache => CacheConfiguration.Instance;
+
+        public CacheTransactionHandler()
         {
-            if (cache == null)
-            {
-                throw new ArgumentNullException("cache");
-            }
-
-            _cache = cache;
         }
 
         public virtual bool GetItem(DbTransaction transaction, string key, out object value)

--- a/EFCache/EFCache.csproj
+++ b/EFCache/EFCache.csproj
@@ -75,6 +75,7 @@
   <ItemGroup>
     <Compile Include="AlwaysCachedQueriesRegistrar.cs" />
     <Compile Include="BlacklistedQueriesRegistrar.cs" />
+    <Compile Include="CacheConfiguration.cs" />
     <Compile Include="CachedResults.cs" />
     <Compile Include="CacheTransactionHandler.cs" />
     <Compile Include="CachingCommand.cs">
@@ -86,6 +87,8 @@
     <Compile Include="CachingPolicy.cs" />
     <Compile Include="DbContextExtensions.cs" />
     <Compile Include="EntityFrameworkCache.cs" />
+    <Compile Include="ICacheQuery.cs" />
+    <Compile Include="InMemoryCacheQuery.cs" />
     <Compile Include="QueryableExtensions.cs" />
     <Compile Include="ICache.cs" />
     <Compile Include="ColumnMetadata.cs" />

--- a/EFCache/EntityFrameworkCache.cs
+++ b/EFCache/EntityFrameworkCache.cs
@@ -12,7 +12,9 @@ namespace EFCache
 
         public static void Initialize(ICache cache, CachingPolicy cachingPolicy)
         {
-            var transactionHandler = new CacheTransactionHandler(cache);
+            CacheConfiguration.ReplaceCache(cache);
+
+            var transactionHandler = new CacheTransactionHandler();
 
             DbConfiguration.Loaded +=
                 (sender, args) => args.ReplaceService<DbProviderServices>(

--- a/EFCache/ICache.cs
+++ b/EFCache/ICache.cs
@@ -41,5 +41,8 @@ namespace EFCache
         /// </summary>
         /// <param name="key">The cache key.</param>
         void InvalidateItem(string key);
+
+
+        ICacheQuery CacheQuery { get; }
     }
 }

--- a/EFCache/ICacheQuery.cs
+++ b/EFCache/ICacheQuery.cs
@@ -1,0 +1,11 @@
+﻿namespace EFCache
+{
+    using System.Data.Entity.Core.Metadata.Edm;
+
+    public interface ICacheQuery
+    {
+        void AddQuery(MetadataWorkspace workspace, string sql);
+        bool RemoveQuery(MetadataWorkspace workspace, string sql);
+        bool ContainsQuery(MetadataWorkspace workspace, string sql);
+    }
+}

--- a/EFCache/InMemoryCache.cs
+++ b/EFCache/InMemoryCache.cs
@@ -160,6 +160,8 @@ namespace EFCache
             get { return _cache.Count; }
         }
 
+        public ICacheQuery CacheQuery => new InMemoryCacheQuery();
+
         private static bool EntryExpired(CacheEntry entry, DateTimeOffset now)
         {
             return entry.AbsoluteExpiration < now || (now - entry.LastAccess) > entry.SlidingExpiration;

--- a/EFCache/InMemoryCacheQuery.cs
+++ b/EFCache/InMemoryCacheQuery.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace EFCache
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Data.Entity.Core.Metadata.Edm;
+
+    internal class InMemoryCacheQuery : ICacheQuery
+    {
+        private readonly ConcurrentDictionary<MetadataWorkspace, HashSet<string>> _queries =
+            new ConcurrentDictionary<MetadataWorkspace, HashSet<string>>();
+
+        public void AddQuery(MetadataWorkspace workspace, string sql)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException("workspace");
+            }
+
+            if (string.IsNullOrWhiteSpace(sql))
+            {
+                throw new ArgumentNullException("sql");
+            }
+
+            var queries = _queries.GetOrAdd(workspace, new HashSet<string>());
+            lock (queries)
+            {
+                queries.Add(sql);
+            }
+        }
+
+        public bool RemoveQuery(MetadataWorkspace workspace, string sql)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException("workspace");
+            }
+
+            if (string.IsNullOrWhiteSpace(sql))
+            {
+                throw new ArgumentNullException("sql");
+            }
+
+            HashSet<string> queries;
+            if (_queries.TryGetValue(workspace, out queries))
+            {
+                lock (queries)
+                {
+                    return queries.Remove(sql);
+                }
+            }
+
+            return false;
+        }
+
+        public bool ContainsQuery(MetadataWorkspace workspace, string sql)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException("workspace");
+            }
+
+            if (string.IsNullOrWhiteSpace(sql))
+            {
+                throw new ArgumentNullException("sql");
+            }
+
+            HashSet<string> queries;
+            if (_queries.TryGetValue(workspace, out queries))
+            {
+                lock (queries)
+                {
+                    return queries.Contains(sql);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/EFCacheTests/CacheTransactionHandlerTests.cs
+++ b/EFCacheTests/CacheTransactionHandlerTests.cs
@@ -16,7 +16,7 @@ namespace EFCache
         {
             Assert.Equal(
                 "cache",
-                Assert.Throws<ArgumentNullException>(() => new CacheTransactionHandler(null)).ParamName);
+                Assert.Throws<ArgumentNullException>(() => new CacheTransactionHandler()).ParamName);
         }
 
         [Fact]
@@ -27,8 +27,10 @@ namespace EFCache
             var mockCache = new Mock<ICache>();
             mockCache.Setup(c => c.GetItem(It.IsAny<string>(), out value)).Returns(true);
 
+            CacheConfiguration.ReplaceCache(mockCache.Object);
+
             Assert.True(
-                new CacheTransactionHandler(mockCache.Object).GetItem(null, "key", out value));
+                new CacheTransactionHandler().GetItem(null, "key", out value));
 
             mockCache.Verify(c => c.GetItem("key", out value), Times.Once());
         }
@@ -41,8 +43,10 @@ namespace EFCache
             var mockCache = new Mock<ICache>();
             mockCache.Setup(c => c.GetItem(It.IsAny<string>(), out value)).Returns(true);
 
+            CacheConfiguration.ReplaceCache(mockCache.Object);
+
             Assert.False(
-                new CacheTransactionHandler(mockCache.Object).GetItem(Mock.Of<DbTransaction>(), "key", out value));
+                new CacheTransactionHandler().GetItem(Mock.Of<DbTransaction>(), "key", out value));
 
             mockCache.Verify(c => c.GetItem(It.IsAny<string>(), out value), Times.Never());
         }
@@ -58,7 +62,9 @@ namespace EFCache
             var timeSpan = new TimeSpan(1500);
             var dateTime = new DateTime(1499);
 
-            new CacheTransactionHandler(mockCache.Object)
+            CacheConfiguration.ReplaceCache(mockCache.Object);
+
+            new CacheTransactionHandler()
                 .PutItem(null, key, value, sets, timeSpan, dateTime);
 
             mockCache.Verify(c => c.PutItem(key, value, sets, timeSpan, dateTime), Times.Once());
@@ -69,7 +75,9 @@ namespace EFCache
         {
             var mockCache = new Mock<ICache>();
 
-            new CacheTransactionHandler(mockCache.Object)
+            CacheConfiguration.ReplaceCache(mockCache.Object);
+
+            new CacheTransactionHandler()
                 .PutItem(Mock.Of<DbTransaction>(), "key", new object(), new string[0], new TimeSpan(), new DateTime());
 
             mockCache.Verify(
@@ -84,7 +92,9 @@ namespace EFCache
 
             var sets = new string[0];
 
-            new CacheTransactionHandler(mockCache.Object)
+            CacheConfiguration.ReplaceCache(mockCache.Object);
+
+            new CacheTransactionHandler()
                 .InvalidateSets(null, sets);
 
             mockCache.Verify(c => c.InvalidateSets(sets), Times.Once());
@@ -94,7 +104,10 @@ namespace EFCache
         public void Committed_invalidate_sets_collected_during_transaction()
         {
             var mockCache = new Mock<ICache>();
-            var transactionHandler = new CacheTransactionHandler(mockCache.Object);
+
+            CacheConfiguration.ReplaceCache(mockCache.Object);
+
+            var transactionHandler = new CacheTransactionHandler();
 
             var transaction = Mock.Of<DbTransaction>();
             transactionHandler.InvalidateSets(transaction, new[] {"ES1", "ES2"});
@@ -109,7 +122,10 @@ namespace EFCache
         public void RolledBack_clears_affected_sets_collected_during_transaction()
         {
             var mockCache = new Mock<ICache>();
-            var transactionHandler = new CacheTransactionHandler(mockCache.Object);
+
+            CacheConfiguration.ReplaceCache(mockCache.Object);
+
+            var transactionHandler = new CacheTransactionHandler();
 
             var transaction = Mock.Of<DbTransaction>();
             transactionHandler.InvalidateSets(transaction, new[] { "ES1", "ES2" });

--- a/EFCacheTests/E2ETest.cs
+++ b/EFCacheTests/E2ETest.cs
@@ -78,6 +78,8 @@ namespace EFCache
         private readonly Dictionary<string, List<string>> _setToCacheKey
             = new Dictionary<string, List<string>>();
 
+        public ICacheQuery CacheQuery => new InMemoryCacheQuery();
+
         public bool GetItem(string key, out object value)
         {
             return CacheDictionary.TryGetValue(key, out value);


### PR DESCRIPTION
Hi Dear Pawel Kadluczka,

First of all, thank you to share the thinking of query cache in EFCache repository..
The problem i had in my enterprise application was the distributed  query cache in Entityframework.
I solved this issue with your code. we need distributed cache by redis. 
ICache Interface is a good interfacing that we can implemented by redis cache provider. But it seems not to support distributed query .

I added ICacheQuery interface for cache query replace QueryRegistrar. QueryRegistrar save query with dictionary in memory but i wanted save query in redis for scale. 
I added ICacheQuery as property in ICache interface.

```C#
interface ICache
{
        bool GetItem(string key, out object value);
        void PutItem(string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration);

        void InvalidateItem(string key);
        ICacheQuery CacheQuery { get; }
}
```

when anybody extend ICache he/she must return CacheQuery object. 

for example InMemoryCacheQuery or RedisCacheQuery.
 
by ICacheQuery+ICache EFCache able to scale.






