### PR TITLE
Support sharded database environment

### DIFF
--- a/EFCache/AlwaysCachedQueriesRegistrar.cs
+++ b/EFCache/AlwaysCachedQueriesRegistrar.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
 
 namespace EFCache
 {

--- a/EFCache/App.config
+++ b/EFCache/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     
@@ -14,4 +14,4 @@
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/EFCache/CacheTransactionHandler.cs
+++ b/EFCache/CacheTransactionHandler.cs
@@ -26,11 +26,11 @@ namespace EFCache
             _cache = cache;
         }
 
-        public virtual bool GetItem(DbTransaction transaction, string key, out object value)
+        public virtual bool GetItem(DbTransaction transaction, string key, out object value, string databaseName = null)
         {
             if (transaction == null)
             {
-                return _cache.GetItem(key, out value);
+                return _cache.GetItem(key, out value, databaseName);
             }
 
             value = null;
@@ -39,19 +39,19 @@ namespace EFCache
         }
 
         public virtual void PutItem(DbTransaction transaction, string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration,
-            DateTimeOffset absoluteExpiration)
+            DateTimeOffset absoluteExpiration, string databaseName = null)
         {
             if (transaction == null)
             {
-                _cache.PutItem(key, value, dependentEntitySets, slidingExpiration, absoluteExpiration);
+                _cache.PutItem(key, value, dependentEntitySets, slidingExpiration, absoluteExpiration, databaseName);
             }
         }
 
-        public virtual void InvalidateSets(DbTransaction transaction, IEnumerable<string> entitySets)
+        public virtual void InvalidateSets(DbTransaction transaction, IEnumerable<string> entitySets, string databaseName = null)
         {
             if (transaction == null)
             {
-                _cache.InvalidateSets(entitySets);
+                _cache.InvalidateSets(entitySets, databaseName);
             }
             else
             {
@@ -90,7 +90,7 @@ namespace EFCache
 
             if (entitySets != null)
             {
-                _cache.InvalidateSets(entitySets.Distinct());
+                _cache.InvalidateSets(entitySets.Distinct(), interceptionContext.Connection.Database);
             }
         }
 

--- a/EFCache/CacheTransactionHandler.cs
+++ b/EFCache/CacheTransactionHandler.cs
@@ -26,11 +26,11 @@ namespace EFCache
             _cache = cache;
         }
 
-        public virtual bool GetItem(DbTransaction transaction, string key, out object value, string databaseName = null)
+        public virtual bool GetItem(DbTransaction transaction, string key, out object value, DbConnection backingConnection = null)
         {
             if (transaction == null)
             {
-                return _cache.GetItem(key, out value, databaseName);
+                return _cache.GetItem(key, out value, backingConnection);
             }
 
             value = null;
@@ -38,20 +38,19 @@ namespace EFCache
             return false;
         }
 
-        public virtual void PutItem(DbTransaction transaction, string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration,
-            DateTimeOffset absoluteExpiration, string databaseName = null)
+        public virtual void PutItem(DbTransaction transaction, string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration, DbConnection backingConnection = null)
         {
             if (transaction == null)
             {
-                _cache.PutItem(key, value, dependentEntitySets, slidingExpiration, absoluteExpiration, databaseName);
+                _cache.PutItem(key, value, dependentEntitySets, slidingExpiration, absoluteExpiration, backingConnection);
             }
         }
 
-        public virtual void InvalidateSets(DbTransaction transaction, IEnumerable<string> entitySets, string databaseName = null)
+        public virtual void InvalidateSets(DbTransaction transaction, IEnumerable<string> entitySets, DbConnection backingConnection = null)
         {
             if (transaction == null)
             {
-                _cache.InvalidateSets(entitySets, databaseName);
+                _cache.InvalidateSets(entitySets, backingConnection);
             }
             else
             {
@@ -90,7 +89,7 @@ namespace EFCache
 
             if (entitySets != null)
             {
-                _cache.InvalidateSets(entitySets.Distinct(), interceptionContext.Connection.Database);
+                _cache.InvalidateSets(entitySets.Distinct(), interceptionContext.Connection);
             }
         }
 

--- a/EFCache/CachingCommand.cs
+++ b/EFCache/CachingCommand.cs
@@ -322,11 +322,11 @@ namespace EFCache
 
 #endif
 
-        private void InvalidateSetsForNonQuery(int recordsAffected, DbConnection backingConnectionName = null)
+        private void InvalidateSetsForNonQuery(int recordsAffected, DbConnection backingConnection = null)
         {
             if (recordsAffected > 0 && _commandTreeFacts.AffectedEntitySets.Any())
             {
-                _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name), backingConnectionName);
+                _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name), backingConnection);
             }
         }
 

--- a/EFCache/CachingCommand.cs
+++ b/EFCache/CachingCommand.cs
@@ -179,7 +179,7 @@ namespace EFCache
 
                 if (!_commandTreeFacts.IsQuery)
                 {
-                    _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name), Connection.Database);
+                    _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name), Connection);
                 }
 
                 return result;
@@ -188,7 +188,7 @@ namespace EFCache
             var key = CreateKey();
 
             object value;
-            if (_cacheTransactionHandler.GetItem(Transaction, key, out value, Connection.Database))
+            if (_cacheTransactionHandler.GetItem(Transaction, key, out value, Connection))
             {
                 return new CachingReader((CachedResults)value);
             }
@@ -218,7 +218,7 @@ namespace EFCache
 
                 if (!_commandTreeFacts.IsQuery)
                 {
-                    _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name), Connection.Database);
+                    _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name), Connection);
                 }
 
                 return result;
@@ -227,7 +227,7 @@ namespace EFCache
             var key = CreateKey();
 
             object value;
-            if (_cacheTransactionHandler.GetItem(Transaction, key, out value, Connection.Database))
+            if (_cacheTransactionHandler.GetItem(Transaction, key, out value, Connection))
             {
                 return new CachingReader((CachedResults)value);
             }
@@ -273,7 +273,7 @@ namespace EFCache
                     _commandTreeFacts.AffectedEntitySets.Select(s => s.Name),
                     slidingExpiration,
                     absoluteExpiration,
-                    Connection.Database);
+                    Connection);
             }
 
             return new CachingReader(cachedResults);
@@ -304,7 +304,7 @@ namespace EFCache
         {
             var recordsAffected = _command.ExecuteNonQuery();
 
-            InvalidateSetsForNonQuery(recordsAffected, Connection.Database);
+            InvalidateSetsForNonQuery(recordsAffected, Connection);
 
             return recordsAffected;
         }
@@ -315,18 +315,18 @@ namespace EFCache
         {
             var recordsAffected = await _command.ExecuteNonQueryAsync(cancellationToken);
 
-            InvalidateSetsForNonQuery(recordsAffected, Connection.Database);
+            InvalidateSetsForNonQuery(recordsAffected, Connection);
 
             return recordsAffected;
         }
 
 #endif
 
-        private void InvalidateSetsForNonQuery(int recordsAffected, string backingDatabaseName = null)
+        private void InvalidateSetsForNonQuery(int recordsAffected, DbConnection backingConnectionName = null)
         {
             if (recordsAffected > 0 && _commandTreeFacts.AffectedEntitySets.Any())
             {
-                _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name), backingDatabaseName);
+                _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name), backingConnectionName);
             }
         }
 
@@ -341,7 +341,7 @@ namespace EFCache
 
             object value;
 
-            if (_cacheTransactionHandler.GetItem(Transaction, key, out value, Connection.Database))
+            if (_cacheTransactionHandler.GetItem(Transaction, key, out value, Connection))
             {
                 return value;
             }
@@ -359,7 +359,7 @@ namespace EFCache
                 _commandTreeFacts.AffectedEntitySets.Select(s => s.Name),
                 slidingExpiration,
                 absoluteExpiration,
-                Connection.Database);
+                Connection);
 
             return value;
         }
@@ -377,7 +377,7 @@ namespace EFCache
 
             object value;
 
-            if (_cacheTransactionHandler.GetItem(Transaction, key, out value, Connection.Database))
+            if (_cacheTransactionHandler.GetItem(Transaction, key, out value, Connection))
             {
                 return value;
             }
@@ -395,7 +395,7 @@ namespace EFCache
                 _commandTreeFacts.AffectedEntitySets.Select(s => s.Name),
                 slidingExpiration,
                 absoluteExpiration,
-                Connection.Database);
+                Connection);
 
             return value;
         }

--- a/EFCache/EFCache.csproj
+++ b/EFCache/EFCache.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -10,12 +10,13 @@
     <RootNamespace>EFCache</RootNamespace>
     <AssemblyName>EFCache</AssemblyName>
     <OutputPath Condition="'$(OutputPath)' == ''">bin\$(Configuration)\</OutputPath>
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' != 'v4.0'">v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' != 'v4.0'">v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <InternalsVisibleToEnabled Condition=" $(InternalsVisibleToEnabled) == ''">true</InternalsVisibleToEnabled>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <DownloadNuGetExe>true</DownloadNuGetExe>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/EFCache/EFCache.csproj
+++ b/EFCache/EFCache.csproj
@@ -94,6 +94,7 @@
     <Compile Include="ObjectContextExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueryRegistrar.cs" />
+    <Compile Include="ShardedCache.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/EFCache/EFCache.csproj
+++ b/EFCache/EFCache.csproj
@@ -72,9 +72,7 @@
     <Compile Include="BlacklistedQueriesRegistrar.cs" />
     <Compile Include="CachedResults.cs" />
     <Compile Include="CacheTransactionHandler.cs" />
-    <Compile Include="CachingCommand.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="CachingCommand.cs" />
     <Compile Include="CachingCommandDefinition.cs" />
     <Compile Include="CachingProviderServices.cs" />
     <Compile Include="CachingReader.cs" />

--- a/EFCache/EFCache.csproj
+++ b/EFCache/EFCache.csproj
@@ -94,7 +94,6 @@
     <Compile Include="ObjectContextExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueryRegistrar.cs" />
-    <Compile Include="ShardedCache.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/EFCache/EFCache.csproj
+++ b/EFCache/EFCache.csproj
@@ -49,20 +49,15 @@
         </Reference>
       </ItemGroup>
     </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-          <SpecificVersion>False</SpecificVersion>
-          <HintPath>..\packages\EntityFramework.6.1.0\lib\net45\EntityFramework.dll</HintPath>
-        </Reference>
-        <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-          <SpecificVersion>False</SpecificVersion>
-          <HintPath>..\packages\EntityFramework.6.1.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-        </Reference>
-      </ItemGroup>
-    </Otherwise>
+    <Otherwise />
   </Choose>
   <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
@@ -97,9 +92,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="TODO.txt" />

--- a/EFCache/ICache.cs
+++ b/EFCache/ICache.cs
@@ -1,6 +1,8 @@
-﻿// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
 
 // Created based on the ICache.cs from Tracing and Caching Provider Wrappers for Entity Framework sample to make it easy to port exisiting applications
+
+using System.Data.Common;
 
 namespace EFCache
 {
@@ -17,8 +19,9 @@ namespace EFCache
         /// </summary>
         /// <param name="key">The cache key.</param>
         /// <param name="value">The retrieved value.</param>
+        /// <param name="backingDatabaseName">The database to be cached against</param>
         /// <returns>A value of <c>true</c> if entry was found in the cache, <c>false</c> otherwise.</returns>
-        bool GetItem(string key, out object value);
+        bool GetItem(string key, out object value, string backingDatabaseName = null);
 
         /// <summary>
         /// Adds the specified entry to the cache.
@@ -28,18 +31,21 @@ namespace EFCache
         /// <param name="dependentEntitySets">The list of dependent entity sets.</param>
         /// <param name="slidingExpiration">The sliding expiration.</param>
         /// <param name="absoluteExpiration">The absolute expiration.</param>
-        void PutItem(string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration);
+        /// <param name="backingDatabaseName">The database to be cached against</param>
+        void PutItem(string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration, string backingDatabaseName = null);
 
         /// <summary>
         /// Invalidates all cache entries which are dependent on any of the specified entity sets.
         /// </summary>
         /// <param name="entitySets">The entity sets.</param>
-        void InvalidateSets(IEnumerable<string> entitySets);
+        /// <param name="backingDatabaseName">The database to be cached against</param>
+        void InvalidateSets(IEnumerable<string> entitySets, string backingDatabaseName = null);
 
         /// <summary>
         /// Invalidates cache entry with a given key.
         /// </summary>
         /// <param name="key">The cache key.</param>
-        void InvalidateItem(string key);
+        /// <param name="backingDatabaseName">The database to be cached against</param>
+        void InvalidateItem(string key, string backingDatabaseName = null);
     }
 }

--- a/EFCache/ICache.cs
+++ b/EFCache/ICache.cs
@@ -19,9 +19,9 @@ namespace EFCache
         /// </summary>
         /// <param name="key">The cache key.</param>
         /// <param name="value">The retrieved value.</param>
-        /// <param name="backingDatabaseName">The database to be cached against</param>
+        /// <param name="backingConnection">The database to be cached against</param>
         /// <returns>A value of <c>true</c> if entry was found in the cache, <c>false</c> otherwise.</returns>
-        bool GetItem(string key, out object value, string backingDatabaseName = null);
+        bool GetItem(string key, out object value, DbConnection backingConnection = null);
 
         /// <summary>
         /// Adds the specified entry to the cache.
@@ -31,21 +31,21 @@ namespace EFCache
         /// <param name="dependentEntitySets">The list of dependent entity sets.</param>
         /// <param name="slidingExpiration">The sliding expiration.</param>
         /// <param name="absoluteExpiration">The absolute expiration.</param>
-        /// <param name="backingDatabaseName">The database to be cached against</param>
-        void PutItem(string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration, string backingDatabaseName = null);
+        /// <param name="backingConnection">The database to be cached against</param>
+        void PutItem(string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration, DbConnection backingConnection = null);
 
         /// <summary>
         /// Invalidates all cache entries which are dependent on any of the specified entity sets.
         /// </summary>
         /// <param name="entitySets">The entity sets.</param>
-        /// <param name="backingDatabaseName">The database to be cached against</param>
-        void InvalidateSets(IEnumerable<string> entitySets, string backingDatabaseName = null);
+        /// <param name="backingConnection">The database to be cached against</param>
+        void InvalidateSets(IEnumerable<string> entitySets, DbConnection backingConnection = null);
 
         /// <summary>
         /// Invalidates cache entry with a given key.
         /// </summary>
         /// <param name="key">The cache key.</param>
-        /// <param name="backingDatabaseName">The database to be cached against</param>
-        void InvalidateItem(string key, string backingDatabaseName = null);
+        /// <param name="backingConnection">The database to be cached against</param>
+        void InvalidateItem(string key, DbConnection backingConnection = null);
     }
 }

--- a/EFCache/InMemoryCache.cs
+++ b/EFCache/InMemoryCache.cs
@@ -5,13 +5,14 @@ namespace EFCache
     using System;
     using System.Linq;
     using System.Collections.Generic;
+    using System.Data.Common;
 
     public class InMemoryCache : ICache
     {
         private readonly Dictionary<string, CacheEntry> _cache = new Dictionary<string, CacheEntry>();
         private readonly Dictionary<string, HashSet<string>> _entitySetToKey = new Dictionary<string, HashSet<string>>();
 
-        public bool GetItem(string key, out object value, string backingDatabaseName)
+        public bool GetItem(string key, out object value, DbConnection backingConnection = null)
         {
             if (key == null)
             {
@@ -29,7 +30,7 @@ namespace EFCache
                 {
                     if (EntryExpired(entry, now))
                     {
-                        InvalidateItem(key, backingDatabaseName);
+                        InvalidateItem(key, backingConnection);
                     }
                     else
                     {
@@ -43,7 +44,7 @@ namespace EFCache
             return false;
         }
 
-        public void PutItem(string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration, string backingDatabaseName)
+        public void PutItem(string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration, DbConnection backingConnection = null)
         {
             if (key == null)
             {
@@ -76,7 +77,7 @@ namespace EFCache
             }
         }
 
-        public void InvalidateSets(IEnumerable<string> entitySets, string backingDatabaseName)
+        public void InvalidateSets(IEnumerable<string> entitySets, DbConnection backingConnection = null)
         {
             if (entitySets == null)
             {
@@ -101,12 +102,12 @@ namespace EFCache
 
                 foreach (var key in itemsToInvalidate)
                 {
-                    InvalidateItem(key, backingDatabaseName);
+                    InvalidateItem(key, backingConnection);
                 }
             }
         }
 
-        public void InvalidateItem(string key, string backingDatabaseName)
+        public void InvalidateItem(string key, DbConnection backingConnection = null)
         {
             if (key == null)
             {
@@ -133,7 +134,7 @@ namespace EFCache
             }
         }
 
-        public void Purge(string databaseName)
+        public void Purge()
         {
             lock (_cache)
             {
@@ -150,7 +151,7 @@ namespace EFCache
 
                 foreach (var key in itemsToRemove)
                 {
-                    InvalidateItem(key, databaseName);
+                    InvalidateItem(key);
                 }
             }
         }

--- a/EFCache/packages.config
+++ b/EFCache/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.0" targetFramework="net45" />
+  <package id="EntityFramework" version="6.2.0" targetFramework="net45" />
 </packages>

--- a/EFCacheTests/App.config
+++ b/EFCacheTests/App.config
@@ -14,4 +14,17 @@
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/EFCacheTests/CacheTransactionHandlerTests.cs
+++ b/EFCacheTests/CacheTransactionHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
 
 namespace EFCache
 {
@@ -25,12 +25,14 @@ namespace EFCache
             object value;
 
             var mockCache = new Mock<ICache>();
-            mockCache.Setup(c => c.GetItem(It.IsAny<string>(), out value)).Returns(true);
+            mockCache.Setup(c => c.GetItem(It.IsAny<string>(), out value,
+					It.IsAny<DbConnection>())).Returns(true);
 
             Assert.True(
                 new CacheTransactionHandler(mockCache.Object).GetItem(null, "key", out value));
 
-            mockCache.Verify(c => c.GetItem("key", out value), Times.Once());
+            mockCache.Verify(c => c.GetItem("key", out value,
+				It.IsAny<DbConnection>()), Times.Once());
         }
 
         [Fact]
@@ -39,12 +41,14 @@ namespace EFCache
             object value;
 
             var mockCache = new Mock<ICache>();
-            mockCache.Setup(c => c.GetItem(It.IsAny<string>(), out value)).Returns(true);
+            mockCache.Setup(c => c.GetItem(It.IsAny<string>(), out value,
+				It.IsAny<DbConnection>())).Returns(true);
 
             Assert.False(
                 new CacheTransactionHandler(mockCache.Object).GetItem(Mock.Of<DbTransaction>(), "key", out value));
 
-            mockCache.Verify(c => c.GetItem(It.IsAny<string>(), out value), Times.Never());
+            mockCache.Verify(c => c.GetItem(It.IsAny<string>(), out value,
+				It.IsAny<DbConnection>()), Times.Never());
         }
 
         [Fact]
@@ -61,7 +65,8 @@ namespace EFCache
             new CacheTransactionHandler(mockCache.Object)
                 .PutItem(null, key, value, sets, timeSpan, dateTime);
 
-            mockCache.Verify(c => c.PutItem(key, value, sets, timeSpan, dateTime), Times.Once());
+            mockCache.Verify(c => c.PutItem(key, value, sets, timeSpan, dateTime,
+				It.IsAny<DbConnection>()), Times.Once());
         }
 
         [Fact]
@@ -74,7 +79,8 @@ namespace EFCache
 
             mockCache.Verify(
                 c => c.PutItem(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IEnumerable<string>>(),
-                    It.IsAny<TimeSpan>(), It.IsAny<DateTime>()), Times.Never());
+                    It.IsAny<TimeSpan>(), It.IsAny<DateTime>(),
+					It.IsAny<DbConnection>()), Times.Never());
         }
 
         [Fact]
@@ -87,7 +93,8 @@ namespace EFCache
             new CacheTransactionHandler(mockCache.Object)
                 .InvalidateSets(null, sets);
 
-            mockCache.Verify(c => c.InvalidateSets(sets), Times.Once());
+            mockCache.Verify(c => c.InvalidateSets(sets,
+				It.IsAny<DbConnection>()), Times.Once());
         }
 
         [Fact]
@@ -102,7 +109,8 @@ namespace EFCache
 
             transactionHandler.Committed(transaction, Mock.Of<DbTransactionInterceptionContext>());
 
-            mockCache.Verify(c =>c.InvalidateSets(new[] {"ES1", "ES2", "ES3"}), Times.Once());
+            mockCache.Verify(c =>c.InvalidateSets(new[] {"ES1", "ES2", "ES3"},
+				It.IsAny<DbConnection>()), Times.Once());
         }
 
         [Fact]
@@ -118,7 +126,8 @@ namespace EFCache
             transactionHandler.RolledBack(transaction, Mock.Of<DbTransactionInterceptionContext>());
             transactionHandler.Committed(transaction, Mock.Of<DbTransactionInterceptionContext>());
 
-            mockCache.Verify(c => c.InvalidateSets(It.IsAny<IEnumerable<string>>()), Times.Never());
+            mockCache.Verify(c => c.InvalidateSets(It.IsAny<IEnumerable<string>>(),
+				It.IsAny<DbConnection>()), Times.Never());
         }
 
     }

--- a/EFCacheTests/CachingCommandDefintionTests.cs
+++ b/EFCacheTests/CachingCommandDefintionTests.cs
@@ -1,13 +1,13 @@
-﻿// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
 
 namespace EFCache
 {
     using Moq;
     using System.Collections.Generic;
     using System.Data.Common;
-    using System.Data.Entity.Core.Common;
     using System.Data.Entity.Core.Metadata.Edm;
     using Xunit;
+    using DbCommandDefinition = System.Data.Entity.Core.Common.DbCommandDefinition;
 
     public class CachingCommandDefintionTests
     {

--- a/EFCacheTests/CachingCommandTests.cs
+++ b/EFCacheTests/CachingCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
 
 namespace EFCache
 {
@@ -399,7 +399,8 @@ namespace EFCache
                     It.Is<CachedResults>(r => r.Results.Count == 1 && r.RecordsAffected == 1 && r.TableMetadata.Length == 2),
                     It.Is<IEnumerable<string>>(es => es.SequenceEqual(new [] { "ES1", "ES2"})),
                     slidingExpiration,
-                    absoluteExpiration),
+                    absoluteExpiration,
+					It.IsAny<DbConnection>()),
                 Times.Once);
         }
 
@@ -425,7 +426,8 @@ namespace EFCache
                 object value;
 
                 mockTransactionHandler.Verify(
-                    c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value),
+                    c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value,
+						It.IsAny<DbConnection>()),
                     Times.Never());
 
                 mockTransactionHandler.Verify(
@@ -435,7 +437,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+						It.IsAny<DbConnection>()),
                     Times.Never);
             }
         }
@@ -462,7 +465,8 @@ namespace EFCache
                 object value;
 
                 mockTransactionHandler.Verify(
-                    c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value),
+                    c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value,
+						It.IsAny<DbConnection>()),
                     Times.Never());
 
                 mockTransactionHandler.Verify(
@@ -472,7 +476,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+						It.IsAny<DbConnection>()),
                     Times.Never);
             }
         }
@@ -521,7 +526,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+						It.IsAny<DbConnection>()),
                     Times.Never);
             }
         }
@@ -573,7 +579,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+						It.IsAny<DbConnection>()),
                     Times.Once);
             }
         }
@@ -587,7 +594,8 @@ namespace EFCache
 
             var mockTransactionHandler = new Mock<CacheTransactionHandler>(Mock.Of<ICache>());
             mockTransactionHandler
-                .Setup(h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value))
+                .Setup(h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value,
+					It.IsAny<DbConnection>()))
                 .Returns(true);
 
             var cachingCommand = new CachingCommand(
@@ -650,7 +658,8 @@ namespace EFCache
             object value;
 
             mockTransactionHandler.Verify(
-                h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out value), Times.Once);
+                h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out value,
+					It.IsAny<DbConnection>()), Times.Once);
 
             mockCommand.Verify(c => c.ExecuteScalar(), Times.Once);
 
@@ -661,7 +670,8 @@ namespace EFCache
                     retValue,
                     new[] {"ES1", "ES2"},
                     slidingExpiration,
-                    absoluteExpiration),
+                    absoluteExpiration,
+					It.IsAny<DbConnection>()),
                     Times.Once);
         }
 
@@ -685,7 +695,8 @@ namespace EFCache
 
             var mockTransactionHandler = new Mock<CacheTransactionHandler>(Mock.Of<ICache>());
             mockTransactionHandler
-                .Setup(h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out retValue))
+                .Setup(h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out retValue,
+					It.IsAny<DbConnection>()))
                 .Returns(true);
 
             var result =
@@ -699,7 +710,8 @@ namespace EFCache
 
             object value;
             mockTransactionHandler.Verify(
-                h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out value), Times.Once);
+                h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out value,
+					It.IsAny<DbConnection>()), Times.Once);
 
             mockCommand.Verify(h => h.ExecuteScalar(), Times.Never);
 
@@ -710,7 +722,8 @@ namespace EFCache
                     It.IsAny<object>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<TimeSpan>(),
-                    It.IsAny<DateTimeOffset>()),
+                    It.IsAny<DateTimeOffset>(),
+					It.IsAny<DbConnection>()),
                     Times.Never);
         }
 
@@ -738,7 +751,8 @@ namespace EFCache
             Assert.Same(retValue, result);
             object value;
             mockTransactionHandler.Verify(
-                h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value), Times.Never);
+                h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value,
+					It.IsAny<DbConnection>()), Times.Never);
 
             mockCommand.Verify(c => c.ExecuteScalar(), Times.Once);
 
@@ -749,7 +763,8 @@ namespace EFCache
                     It.IsAny<object>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<TimeSpan>(),
-                    It.IsAny<DateTimeOffset>()),
+                    It.IsAny<DateTimeOffset>(),
+					It.IsAny<DbConnection>()),
                     Times.Never);
         }
 
@@ -782,7 +797,8 @@ namespace EFCache
             Assert.Same(retValue, result);
             object value;
             mockTransactionHandler.Verify(
-                h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value), Times.Never);
+                h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value,
+					It.IsAny<DbConnection>()), Times.Never);
 
             mockCommand.Verify(c => c.ExecuteScalar(), Times.Once);
 
@@ -793,7 +809,8 @@ namespace EFCache
                     It.IsAny<object>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<TimeSpan>(),
-                    It.IsAny<DateTimeOffset>()),
+                    It.IsAny<DateTimeOffset>(),
+					It.IsAny<DbConnection>()),
                     Times.Never);
         }
 
@@ -817,7 +834,8 @@ namespace EFCache
             Assert.Equal(rowsAffected, 1);
             mockCommand.Verify(c => c.ExecuteNonQuery(), Times.Once());
             mockTransactionHandler
-                .Verify(h => h.InvalidateSets(transaction, new[] { "ES1", "ES2" }), Times.Once());
+                .Verify(h => h.InvalidateSets(transaction, new[] { "ES1", "ES2" },
+					It.IsAny<DbConnection>()), Times.Once());
         }
 
         [Fact]
@@ -839,7 +857,8 @@ namespace EFCache
             Assert.Equal(rowsAffected, 0);
             mockCommand.Verify(c => c.ExecuteNonQuery(), Times.Once());
             mockTransactionHandler
-                .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>()), Times.Never());
+                .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>(),
+					It.IsAny<DbConnection>()), Times.Never());
         }
 
         [Fact]
@@ -861,7 +880,8 @@ namespace EFCache
             Assert.Equal(rowsAffected, 1);
             mockCommand.Verify(c => c.ExecuteNonQuery(), Times.Once());
             mockTransactionHandler
-                .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>()), Times.Never());
+                .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>(),
+					It.IsAny<DbConnection>()), Times.Never());
         }
 
         [Fact]
@@ -1039,7 +1059,8 @@ namespace EFCache
                 Assert.Equal(rowsAffected, 1);
                 mockCommand.Verify(c => c.ExecuteNonQueryAsync(It.IsAny<CancellationToken>()), Times.Once());
                 mockTransactionHandler
-                    .Verify(h => h.InvalidateSets(transaction, new[] {"ES1", "ES2"}), Times.Once());
+                    .Verify(h => h.InvalidateSets(transaction, new[] {"ES1", "ES2"},
+						It.IsAny<DbConnection>()), Times.Once());
             }
 
             [Fact]
@@ -1061,7 +1082,8 @@ namespace EFCache
                 Assert.Equal(rowsAffected, 0);
                 mockCommand.Verify(c => c.ExecuteNonQueryAsync(It.IsAny<CancellationToken>()), Times.Once());
                 mockTransactionHandler
-                    .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>()),
+                    .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>(),
+							It.IsAny<DbConnection>()),
                         Times.Never());
             }
 
@@ -1086,7 +1108,8 @@ namespace EFCache
                 Assert.Equal(rowsAffected, 1);
                 mockCommand.Verify(c => c.ExecuteNonQueryAsync(It.IsAny<CancellationToken>()), Times.Once());
                 mockTransactionHandler
-                    .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>()),
+                    .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>(),
+							It.IsAny<DbConnection>()),
                         Times.Never());
             }
 
@@ -1155,7 +1178,8 @@ namespace EFCache
                 object value;
 
                 mockTransactionHandler.Verify(
-                    h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out value), Times.Once);
+                    h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out value,
+						It.IsAny<DbConnection>()), Times.Once);
 
                 mockCommand.Verify(c => c.ExecuteScalarAsync(It.IsAny<CancellationToken>()), Times.Once);
 
@@ -1166,7 +1190,8 @@ namespace EFCache
                         retValue,
                         new[] {"ES1", "ES2"},
                         slidingExpiration,
-                        absoluteExpiration),
+                        absoluteExpiration,
+						It.IsAny<DbConnection>()),
                     Times.Once);
             }
 
@@ -1190,7 +1215,8 @@ namespace EFCache
 
                 var mockTransactionHandler = new Mock<CacheTransactionHandler>(Mock.Of<ICache>());
                 mockTransactionHandler
-                    .Setup(h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out retValue))
+                    .Setup(h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out retValue,
+						It.IsAny<DbConnection>()))
                     .Returns(true);
 
                 var result =
@@ -1204,7 +1230,8 @@ namespace EFCache
 
                 object value;
                 mockTransactionHandler.Verify(
-                    h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out value), Times.Once);
+                    h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out value,
+						It.IsAny<DbConnection>()), Times.Once);
 
                 mockCommand.Verify(h => h.ExecuteScalarAsync(It.IsAny<CancellationToken>()), Times.Never);
 
@@ -1215,7 +1242,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+						It.IsAny<DbConnection>()),
                     Times.Never);
             }
 
@@ -1243,7 +1271,8 @@ namespace EFCache
                 Assert.Same(retValue, result);
                 object value;
                 mockTransactionHandler.Verify(
-                    h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value), Times.Never);
+                    h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value,
+						It.IsAny<DbConnection>()), Times.Never);
 
                 mockCommand.Verify(c => c.ExecuteScalarAsync(It.IsAny<CancellationToken>()), Times.Once);
 
@@ -1254,7 +1283,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+						It.IsAny<DbConnection>()),
                     Times.Never);
             }
 
@@ -1287,7 +1317,8 @@ namespace EFCache
                 Assert.Same(retValue, result);
                 object value;
                 mockTransactionHandler.Verify(
-                    h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value), Times.Never);
+                    h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value,
+						It.IsAny<DbConnection>()), Times.Never);
 
                 mockCommand.Verify(c => c.ExecuteScalarAsync(It.IsAny<CancellationToken>()), Times.Once);
 
@@ -1298,7 +1329,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+						It.IsAny<DbConnection>()),
                     Times.Never);
             }
 
@@ -1429,7 +1461,8 @@ namespace EFCache
                             r => r.Results.Count == 1 && r.RecordsAffected == 1 && r.TableMetadata.Length == 2),
                         It.Is<IEnumerable<string>>(es => es.SequenceEqual(new[] {"ES1", "ES2"})),
                         slidingExpiration,
-                        absoluteExpiration),
+                        absoluteExpiration,
+						It.IsAny<DbConnection>()),
                     Times.Once);
             }
 
@@ -1455,7 +1488,8 @@ namespace EFCache
                     object value;
 
                     mockTransactionHandler.Verify(
-                        c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value),
+                        c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value,
+							It.IsAny<DbConnection>()),
                         Times.Never());
 
                     mockTransactionHandler.Verify(
@@ -1465,7 +1499,8 @@ namespace EFCache
                             It.IsAny<object>(),
                             It.IsAny<IEnumerable<string>>(),
                             It.IsAny<TimeSpan>(),
-                            It.IsAny<DateTimeOffset>()),
+                            It.IsAny<DateTimeOffset>(),
+							It.IsAny<DbConnection>()),
                         Times.Never);
                 }
             }
@@ -1492,7 +1527,8 @@ namespace EFCache
                     object value;
 
                     mockTransactionHandler.Verify(
-                        c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value),
+                        c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value,
+							It.IsAny<DbConnection>()),
                         Times.Never());
 
                     mockTransactionHandler.Verify(
@@ -1502,7 +1538,8 @@ namespace EFCache
                             It.IsAny<object>(),
                             It.IsAny<IEnumerable<string>>(),
                             It.IsAny<TimeSpan>(),
-                            It.IsAny<DateTimeOffset>()),
+                            It.IsAny<DateTimeOffset>(),
+							It.IsAny<DbConnection>()),
                         Times.Never);
                 }
             }
@@ -1551,7 +1588,8 @@ namespace EFCache
                             It.IsAny<object>(),
                             It.IsAny<IEnumerable<string>>(),
                             It.IsAny<TimeSpan>(),
-                            It.IsAny<DateTimeOffset>()),
+                            It.IsAny<DateTimeOffset>(),
+							It.IsAny<DbConnection>()),
                         Times.Never);
                 }
             }
@@ -1565,7 +1603,8 @@ namespace EFCache
 
                 var mockTransactionHandler = new Mock<CacheTransactionHandler>(Mock.Of<ICache>());
                 mockTransactionHandler
-                    .Setup(h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value))
+                    .Setup(h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value,
+						It.IsAny<DbConnection>()))
                     .Returns(true);
 
                 var cachingCommand = new CachingCommand(

--- a/EFCacheTests/CachingProviderServicesTests.cs
+++ b/EFCacheTests/CachingProviderServicesTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
 
 namespace EFCache
 {
@@ -6,7 +6,6 @@ namespace EFCache
     using Moq.Protected;
     using System;
     using System.Data.Common;
-    using System.Data.Entity.Core.Common;
     using System.Data.Entity.Core.Common.CommandTrees;
     using System.Data.Entity.Core.Common.CommandTrees.ExpressionBuilder;
     using System.Data.Entity.Core.Metadata.Edm;
@@ -15,6 +14,10 @@ namespace EFCache
     using System.Xml;
     using System.Xml.Linq;
     using Xunit;
+    using DbProviderServices = System.Data.Entity.Core.Common.DbProviderServices;
+    using DbProviderManifest = System.Data.Entity.Core.Common.DbProviderManifest;
+    using DbCommandDefinition = System.Data.Entity.Core.Common.DbCommandDefinition;
+
 
     public class CachingProviderServicesTests
     {

--- a/EFCacheTests/E2ETest.cs
+++ b/EFCacheTests/E2ETest.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Data.Common;
 
 namespace EFCache
 {
@@ -78,12 +80,12 @@ namespace EFCache
         private readonly Dictionary<string, List<string>> _setToCacheKey
             = new Dictionary<string, List<string>>();
 
-        public bool GetItem(string key, out object value)
+        public bool GetItem(string key, out object value, DbConnection dbConnection)
         {
             return CacheDictionary.TryGetValue(key, out value);
         }
 
-        public void PutItem(string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration)
+        public void PutItem(string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration, DbConnection dbConnection)
         {
             CacheDictionary[key] = value;
 
@@ -100,7 +102,7 @@ namespace EFCache
             }
         }
 
-        public void InvalidateSets(IEnumerable<string> entitySets)
+        public void InvalidateSets(IEnumerable<string> entitySets, DbConnection dbConnection)
         {
             foreach (var set in entitySets)
             {
@@ -117,7 +119,7 @@ namespace EFCache
             }
         }
 
-        public void InvalidateItem(string key)
+        public void InvalidateItem(string key, DbConnection dbConnection)
         {
             throw new NotImplementedException();
         }
@@ -160,7 +162,7 @@ namespace EFCache
         [Fact]
         public void Cache_cleared_on_implicit_transaction_commit()
         {
-            Cache.PutItem("s", new object(), new[] {"Item", "Entity"}, new TimeSpan(), new DateTime());
+            Cache.PutItem("s", new object(), new[] {"Item", "Entity"}, new TimeSpan(), new DateTime(), null);
 
             using (var ctx = new MyContext())
             {
@@ -176,7 +178,7 @@ namespace EFCache
         [Fact]
         public void Cache_cleared_on_explicit_transaction_commit()
         {
-            Cache.PutItem("s", new object(), new[] { "Item", "Entity" }, new TimeSpan(), new DateTime());
+            Cache.PutItem("s", new object(), new[] { "Item", "Entity" }, new TimeSpan(), new DateTime(), null);
 
             using (var ctx = new MyContext())
             {
@@ -202,7 +204,7 @@ namespace EFCache
         [Fact]
         public async Task Cache_cleared_on_explicit_transaction_commit_Async()
         {
-            Cache.PutItem("s", new object(), new[] { "Item", "Entity" }, new TimeSpan(), new DateTime());
+            Cache.PutItem("s", new object(), new[] { "Item", "Entity" }, new TimeSpan(), new DateTime(), null);
 
             using (var ctx = new MyContext())
             {
@@ -228,7 +230,7 @@ namespace EFCache
         [Fact]
         public void Cache_not_cleared_on_transaction_rollback()
         {
-            Cache.PutItem("s", new object(), new[] { "Item", "Entity" }, new TimeSpan(), new DateTime());
+            Cache.PutItem("s", new object(), new[] { "Item", "Entity" }, new TimeSpan(), new DateTime(), null);
 
             using (var ctx = new MyContext())
             {

--- a/EFCacheTests/EFCacheTests.csproj
+++ b/EFCacheTests/EFCacheTests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\EFCache.Temp\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\EFCache.Temp\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\..\EFCache.Temp\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\..\..\EFCache.Temp\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -10,12 +12,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EFCache</RootNamespace>
     <AssemblyName>EFCacheTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,46 +38,46 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\..\EFCache.Temp\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.1.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>..\..\..\EFCache.Temp\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.1.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>..\..\..\EFCache.Temp\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="Moq, Version=4.5.28.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.5.28\lib\net45\Moq.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\..\EFCache.Temp\packages\Moq.4.8.2\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\EFCache.Temp\packages\System.Threading.Tasks.Extensions.4.4.0\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\EFCache.Temp\packages\System.ValueTuple.4.4.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <HintPath>..\..\..\EFCache.Temp\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.assert, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\EFCache.Temp\packages\xunit.assert.2.3.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.core, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\EFCache.Temp\packages\xunit.extensibility.core.2.3.1\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.execution.desktop, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\EFCache.Temp\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -110,6 +113,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\..\EFCache.Temp\packages\xunit.analyzers.0.8.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -118,7 +124,11 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\..\EFCache.Temp\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\EFCache.Temp\packages\xunit.core.2.3.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\..\EFCache.Temp\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\EFCache.Temp\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\..\EFCache.Temp\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\EFCache.Temp\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
+  <Import Project="..\..\..\EFCache.Temp\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\..\..\EFCache.Temp\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EFCacheTests/packages.config
+++ b/EFCacheTests/packages.config
@@ -1,13 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="EntityFramework" version="6.1.0" targetFramework="net45" />
-  <package id="Moq" version="4.5.28" targetFramework="net45" />
-  <package id="xunit" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+  <package id="Castle.Core" version="4.2.1" targetFramework="net47" />
+  <package id="EntityFramework" version="6.2.0" targetFramework="net47" />
+  <package id="Moq" version="4.8.2" targetFramework="net47" />
+  <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net47" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net47" />
+  <package id="xunit" version="2.3.1" targetFramework="net47" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net47" />
+  <package id="xunit.analyzers" version="0.8.0" targetFramework="net47" />
+  <package id="xunit.assert" version="2.3.1" targetFramework="net47" />
+  <package id="xunit.core" version="2.3.1" targetFramework="net47" />
+  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net47" />
+  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net47" />
+  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net47" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
These commits support the use use of a 1:1 redis<->db mapping. It does so by passing the `DbConnection` through the various interception methods as a parameter, allowing a potential `ICache` instance to examine the `DbConnection` instance to maintain said mapping.

See https://github.com/purdue-tlt/EFCache.Sharding for an implementation of a sharded cache.