### PR TITLE
Added InMemoryCache Features

### DIFF
--- a/EFCache/ICache.cs
+++ b/EFCache/ICache.cs
@@ -41,5 +41,16 @@ namespace EFCache
         /// </summary>
         /// <param name="key">The cache key.</param>
         void InvalidateItem(string key);
+
+        /// <summary>
+        /// Calculates and returns the cache size in bytes
+        /// </summary>
+        /// <returns>The cache size in bytes</returns>
+        int GetCacheSize();
+
+        /// <summary>
+        /// Returns a list of all cached entity sets
+        /// </summary>
+        IEnumerable<string> EntitySetsInCache { get; }
     }
 }

--- a/EFCacheTests/E2ETest.cs
+++ b/EFCacheTests/E2ETest.cs
@@ -78,6 +78,8 @@ namespace EFCache
         private readonly Dictionary<string, List<string>> _setToCacheKey
             = new Dictionary<string, List<string>>();
 
+        public IEnumerable<string> EntitySetsInCache => _setToCacheKey.Select(x => x.Key);
+
         public bool GetItem(string key, out object value)
         {
             return CacheDictionary.TryGetValue(key, out value);
@@ -118,6 +120,11 @@ namespace EFCache
         }
 
         public void InvalidateItem(string key)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int GetCacheSize()
         {
             throw new NotImplementedException();
         }

--- a/EFCacheTests/InMemoryCacheTests.cs
+++ b/EFCacheTests/InMemoryCacheTests.cs
@@ -3,6 +3,8 @@
 namespace EFCache
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Xunit;
 
     public class InMemoryCacheTests
@@ -59,7 +61,7 @@ namespace EFCache
             cache.PutItem("3", new object(), new[] { "ES1", "ES3", "ES4" }, TimeSpan.MaxValue, DateTimeOffset.MaxValue);
             cache.PutItem("4", new object(), new[] { "ES3", "ES4" }, TimeSpan.MaxValue, DateTimeOffset.MaxValue);
 
-            cache.InvalidateSets(new [] {"ES1", "ES2"});
+            cache.InvalidateSets(new[] { "ES1", "ES2" });
 
             object item;
             Assert.False(cache.GetItem("1", out item));
@@ -75,7 +77,7 @@ namespace EFCache
 
             cache.PutItem("1", new object(), new[] { "ES1", "ES2" }, TimeSpan.MaxValue, DateTimeOffset.MaxValue);
             cache.InvalidateItem("1");
-            
+
             object item;
             Assert.False(cache.GetItem("1", out item));
         }
@@ -169,6 +171,36 @@ namespace EFCache
             Assert.Equal(
                 "key",
                 Assert.Throws<ArgumentNullException>(() => new InMemoryCache().InvalidateItem(null)).ParamName);
+        }
+
+        [Fact]
+        public void GetEntitySets_returns_all_cached_entitysets()
+        {
+            var cache = new InMemoryCache();
+            var item = new object();
+
+            var entitySets = new List<string> { "table1", "table2", "table3" };
+
+            cache.PutItem("key", item, entitySets, TimeSpan.MaxValue, DateTimeOffset.MaxValue);
+
+            var inCache = cache.EntitySetsInCache.ToList();
+
+            Assert.Equal(entitySets, inCache);
+        }
+
+        [Fact]
+        public void GetCacheSize_returns_current_size_of_object()
+        {
+            var cache = new InMemoryCache();
+            var item = new object();
+
+            var entitySets = new List<string> { "table1", "table2", "table3" };
+
+            cache.PutItem("key", item, entitySets, TimeSpan.MaxValue, DateTimeOffset.MaxValue);
+
+            var size = cache.GetCacheSize();
+
+            Assert.True(size > 0);
         }
     }
 }


### PR DESCRIPTION
Added support for the following operations on the InMemoryCache object

- GetCacheSize (returns cache size in bytes)
- EntitySetsInCache (returns a list of all currently cached entity sets)