### PR TITLE
Fix NullReferenceException for partial CRUD entity

### DIFF
--- a/EFCache/CommandTreeFacts.cs
+++ b/EFCache/CommandTreeFacts.cs
@@ -49,9 +49,9 @@ namespace EFCache
                 var entitySetMappings =
                 containerMapping.EntitySetMappings.Where(
                     esm => esm.ModificationFunctionMappings.Any(
-                        mfm => mfm.DeleteFunctionMapping.Function == edmFunction ||
-                        mfm.InsertFunctionMapping.Function == edmFunction ||
-                        mfm.UpdateFunctionMapping.Function == edmFunction));
+                        mfm => mfm.DeleteFunctionMapping?.Function == edmFunction ||
+                        mfm.InsertFunctionMapping?.Function == edmFunction ||
+                        mfm.UpdateFunctionMapping?.Function == edmFunction));
 
                 AffectedEntitySets =
                     (from esm in entitySetMappings


### PR DESCRIPTION
Entity with partial insert/update/delete function mapping generate a NullReferenceException when searching for affected entity sets in CommandTreeFacts.