### PR TITLE
Null ref getting connection from transaction

### DIFF
--- a/EFCache/CacheTransactionHandler.cs
+++ b/EFCache/CacheTransactionHandler.cs
@@ -88,7 +88,7 @@ namespace EFCache
 
             if (entitySets != null)
             {
-                ResolveCache(transaction.Connection).InvalidateSets(entitySets.Distinct());
+                ResolveCache(interceptionContext.Connection).InvalidateSets(entitySets.Distinct());
             }
         }
 


### PR DESCRIPTION
Hi Pawel - we finally grabbed your latest NuGet, but it appears there are some conditions where the `CacheTransactionHandler` is trying to resolve the `Connection` in the `Committed` event and failing because it's trying to get it from the Transaction and the transaction is null. This appears to solve that problem. Let me know if this is the right approach to fix this.

Thank you!