### PR TITLE
Implement ISerializable on ColumnMetadata to support BinaryFormatter …

### DIFF
--- a/src/EFCache/ColumnMetadata.cs
+++ b/src/EFCache/ColumnMetadata.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
-
-using System.Runtime.Serialization;
-
 namespace EFCache
 {
     using System;
+    using System.Runtime.Serialization;
 
     [Serializable]
     internal struct ColumnMetadata : ISerializable

--- a/src/EFCache/ColumnMetadata.cs
+++ b/src/EFCache/ColumnMetadata.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Runtime.Serialization;
+
 namespace EFCache
 {
     using System;
 
     [Serializable]
-    internal struct ColumnMetadata
+    internal struct ColumnMetadata : ISerializable
     {
         private readonly string _name;
         private readonly string _dataTypeName;
@@ -16,6 +18,14 @@ namespace EFCache
             _name = name;
             _dataTypeName = dataTypeName;
             _dataType = dataType;
+        }
+
+        public ColumnMetadata(SerializationInfo info, StreamingContext context)
+        {
+            // Reset the property value using the GetValue method.
+            _name = (string) info.GetValue("name", typeof(string));
+            _dataTypeName = (string) info.GetValue("datatypename", typeof(string));
+            _dataType = Type.GetType((string) info.GetValue("datatype", typeof(string)));
         }
 
         public string Name
@@ -31,6 +41,13 @@ namespace EFCache
         public Type DataType
         {
             get { return _dataType; }
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("datatypename", _dataTypeName);
+            info.AddValue("datatype", DataType.FullName);
+            info.AddValue("name", Name);
         }
     }
 }

--- a/test/EFCacheTests/BinaryFormatterTests.cs
+++ b/test/EFCacheTests/BinaryFormatterTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
+using Xunit;
+
+namespace EFCache
+{
+    public class BinaryFormatterTests
+    {
+        [Fact]
+        public void CachedResults_binary_formatter_can_serialize()
+        {
+            var tableMetadata = new ColumnMetadata[]
+            {
+                new ColumnMetadata("age", "int", typeof(System.Int32))
+            };
+            
+            var cachedResults = new CachedResults(tableMetadata, new List<object[]>{new object[]{105}}, 1);
+            var formatter = new BinaryFormatter();
+
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, cachedResults);
+                stream.Seek(0L, SeekOrigin.Begin);
+                var deserialized = (CachedResults)formatter.Deserialize(stream);
+                
+                Assert.Equal(1, deserialized.RecordsAffected);
+                Assert.Equal("age", deserialized.TableMetadata.Single().Name);
+                Assert.Equal("int", deserialized.TableMetadata.Single().DataTypeName);
+                Assert.Equal(105, deserialized.Results[0][0]);
+            }
+        }
+    }
+}

--- a/test/EFCacheTests/BinaryFormatterTests.cs
+++ b/test/EFCacheTests/BinaryFormatterTests.cs
@@ -1,17 +1,17 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.Serialization.Formatters.Binary;
-using Xunit;
-
-namespace EFCache
+﻿namespace EFCache
 {
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Xunit;
+
     public class BinaryFormatterTests
     {
         [Fact]
         public void CachedResults_binary_formatter_can_serialize()
         {
-            var tableMetadata = new ColumnMetadata[]
+            var tableMetadata = new[]
             {
                 new ColumnMetadata("age", "int", typeof(System.Int32))
             };
@@ -28,6 +28,7 @@ namespace EFCache
                 Assert.Equal(1, deserialized.RecordsAffected);
                 Assert.Equal("age", deserialized.TableMetadata.Single().Name);
                 Assert.Equal("int", deserialized.TableMetadata.Single().DataTypeName);
+                Assert.Equal(typeof(System.Int32), deserialized.TableMetadata.Single().DataType);
                 Assert.Equal(105, deserialized.Results[0][0]);
             }
         }


### PR DESCRIPTION
When using EFCache.Redis to set up 2nd level caching in a dotnet core project, the BinaryFormatter is used to serialize the cached objects. However, since dotnet core 2, System.RuntimeType is no longer marked as serializable. 

As stated [here](https://github.com/dotnet/runtime/issues/23169), this pull request takes over the serialization via the ISerializable interface implementation on ColumnMetadata.

