### PR TITLE
Use a generic ICache interface for caching implementation

### DIFF
--- a/src/EFCache/EntityFrameworkCache.cs
+++ b/src/EFCache/EntityFrameworkCache.cs
@@ -19,5 +19,16 @@ namespace EFCache
                     (dbServices, _) => new CachingProviderServices(dbServices, transactionHandler, cachingPolicy));
             DbInterception.Add(transactionHandler);
         }
+
+        public static void Initialize(ICacheProvider cache) => Initialize(cache, new CachingPolicy());
+        public static void Initialize(ICacheProvider cache, CachingPolicy cachingPolicy)
+        {
+            var transactionHandler = new CacheTransactionHandler(cache);
+
+            DbConfiguration.Loaded +=
+                (sender, args) => args.ReplaceService<DbProviderServices>(
+                    (dbServices, _) => new CachingProviderServices(dbServices, transactionHandler, cachingPolicy));
+            DbInterception.Add(transactionHandler);
+        }
     }
 }

--- a/src/EFCache/ICacheItemInvalidation.cs
+++ b/src/EFCache/ICacheItemInvalidation.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EFCache
+{
+    public interface ICacheItemInvalidation
+    {
+        /// <summary>
+        /// Invalidates cache entry with a given key.
+        /// </summary>
+        /// <param name="key">The cache key.</param>
+        void InvalidateItem(string key);
+    }
+}

--- a/src/EFCache/ICacheProvider.cs
+++ b/src/EFCache/ICacheProvider.cs
@@ -1,16 +1,12 @@
-﻿// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
-
-// Created based on the ICache.cs from Tracing and Caching Provider Wrappers for Entity Framework sample to make it easy to port exisiting applications
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace EFCache
 {
-    using System;
-    using System.Collections.Generic;
-
-    /// <summary>
-    /// Interface to be implemented by cache implementations.
-    /// </summary>
-    public interface ICache
+    public interface ICacheProvider : ICache
     {
         /// <summary>
         /// Tries to the get cached entry by key.
@@ -18,7 +14,7 @@ namespace EFCache
         /// <param name="key">The cache key.</param>
         /// <param name="value">The retrieved value.</param>
         /// <returns>A value of <c>true</c> if entry was found in the cache, <c>false</c> otherwise.</returns>
-        bool GetItem(string key, out object value);
+        bool GetItem<TObject>(string key, out TObject value);
 
         /// <summary>
         /// Adds the specified entry to the cache.
@@ -28,12 +24,12 @@ namespace EFCache
         /// <param name="dependentEntitySets">The list of dependent entity sets.</param>
         /// <param name="slidingExpiration">The sliding expiration.</param>
         /// <param name="absoluteExpiration">The absolute expiration.</param>
-        void PutItem(string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration);
+        void PutItem<TObject>(string key, TObject value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration);
 
         /// <summary>
         /// Invalidates all cache entries which are dependent on any of the specified entity sets.
         /// </summary>
         /// <param name="entitySets">The entity sets.</param>
-        void InvalidateSets(IEnumerable<string> entitySets);
+        new void InvalidateSets(IEnumerable<string> entitySets);
     }
 }

--- a/test/EFCacheTests/CacheTransactionHandlerTests.cs
+++ b/test/EFCacheTests/CacheTransactionHandlerTests.cs
@@ -17,7 +17,7 @@ namespace EFCache
         {
             Assert.Equal(
                 "cache",
-                Assert.Throws<ArgumentNullException>(() => new CacheTransactionHandler(null)).ParamName);
+                Assert.Throws<ArgumentNullException>(() => new CacheTransactionHandler(cache:null)).ParamName);
         }
 
         [Fact]
@@ -128,8 +128,8 @@ namespace EFCache
         {
             var transactionHandler = new Mock<CacheTransactionHandler>{ CallBase = true }.Object;
 
-            Assert.Throws<InvalidOperationException>(() =>
-                transactionHandler.GetItem(null, "key", Mock.Of<DbConnection>(), out _));
+            Assert.ThrowsAny<InvalidOperationException>(() =>
+                transactionHandler.GetItem(null, "key", Mock.Of<DbConnection>(), out object _));
         }
 
         [Fact]
@@ -141,7 +141,7 @@ namespace EFCache
                 .Returns(Mock.Of<ICache>());
             var dbConnection = Mock.Of<DbConnection>();
 
-            mockTransactionHandler.Object.GetItem(null, "key", dbConnection, out _);
+            mockTransactionHandler.Object.GetItem(null, "key", dbConnection, out object _);
 
             mockTransactionHandler.Protected()
                 .Verify("ResolveCache", Times.Once(), dbConnection);


### PR DESCRIPTION
Motivation:
1. I want to use redis cache using Easycaching.Redis library and while deserialising CachedResult class, I get an error when converting using Newtonsoft.Json serializer because deserialisation target type can't be found.

I've taken careful measures to not break previous library version.
Request to accept the change or provide comments for improvement.