### PR TITLE
Feature allow changing caching strategy

### DIFF
--- a/src/EFCache/CachedResults.cs
+++ b/src/EFCache/CachedResults.cs
@@ -6,7 +6,7 @@ namespace EFCache
     using System.Collections.Generic;
 
     [Serializable]
-    internal class CachedResults
+    public class CachedResults
     {
         private readonly ColumnMetadata[] _tableMetadata;
         private readonly List<object[]> _results;

--- a/src/EFCache/CachingCommandDefinition.cs
+++ b/src/EFCache/CachingCommandDefinition.cs
@@ -13,6 +13,7 @@ namespace EFCache
         private readonly CommandTreeFacts _commandTreeFacts;
         private readonly CacheTransactionHandler _cacheTransactionHandler;
         private readonly CachingPolicy _cachingPolicy;
+        private readonly CachingCommandStrategyFactory _cachingCommandStrategyFactory;
 
         public bool IsQuery
         {
@@ -29,17 +30,30 @@ namespace EFCache
             get { return _commandTreeFacts.AffectedEntitySets; }
         }
 
-        public CachingCommandDefinition(DbCommandDefinition commandDefinition, CommandTreeFacts commandTreeFacts, CacheTransactionHandler cacheTransactionHandler, CachingPolicy cachingPolicy)
+        public CachingCommandDefinition(DbCommandDefinition commandDefinition,
+            CommandTreeFacts commandTreeFacts,
+            CacheTransactionHandler cacheTransactionHandler,
+            CachingPolicy cachingPolicy)
         {
             _commandDefintion = commandDefinition;
             _commandTreeFacts = commandTreeFacts;
             _cacheTransactionHandler = cacheTransactionHandler;
             _cachingPolicy = cachingPolicy;
+            _cachingCommandStrategyFactory = DefaultCachingCommandFactory.Create;
+        }
+
+        public CachingCommandDefinition(DbCommandDefinition commandDefinition, 
+            CommandTreeFacts commandTreeFacts, 
+            CacheTransactionHandler cacheTransactionHandler, 
+            CachingPolicy cachingPolicy,
+            CachingCommandStrategyFactory cachingCommandStrategyFactory) : this(commandDefinition, commandTreeFacts, cacheTransactionHandler, cachingPolicy)
+        {
+            _cachingCommandStrategyFactory = cachingCommandStrategyFactory;
         }
 
         public override DbCommand CreateCommand()
         {
-            return new CachingCommand(_commandDefintion.CreateCommand(), _commandTreeFacts, _cacheTransactionHandler, _cachingPolicy);
+            return new CachingCommand(_commandDefintion.CreateCommand(), _commandTreeFacts, _cacheTransactionHandler, _cachingPolicy, _cachingCommandStrategyFactory);
         }
     }
 }

--- a/src/EFCache/CachingCommandStrategy.cs
+++ b/src/EFCache/CachingCommandStrategy.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EFCache
+{
+    public delegate ICachingCommandStrategy CachingCommandStrategyFactory(CachingPolicy cachingPolicy,
+        ICommandTreeFacts commandTreeFacts,
+        CacheTransactionHandler cacheTransactionHandler,
+        DbCommand command);
+
+    public static class DefaultCachingCommandFactory
+    {
+        public static ICachingCommandStrategy Create(CachingPolicy cachingPolicy,
+            ICommandTreeFacts commandTreeFacts,
+            CacheTransactionHandler cacheTransactionHandler,
+            DbCommand command)
+        {
+            return new CachingCommandStrategy(cachingPolicy, commandTreeFacts, cacheTransactionHandler, command);
+        }
+    }
+
+    public class CachingCommandStrategy : ICachingCommandStrategy
+    {
+        protected readonly CachingPolicy _cachingPolicy;
+        protected readonly ICommandTreeFacts _commandTreeFacts;
+        protected readonly CacheTransactionHandler _cacheTransactionHandler;
+        protected readonly DbCommand _command;
+
+        public CachingCommandStrategy(CachingPolicy cachingPolicy,
+            ICommandTreeFacts commandTreeFacts,
+            CacheTransactionHandler cacheTransactionHandler,
+            DbCommand command)
+        {
+            _cachingPolicy = cachingPolicy;
+            _commandTreeFacts = commandTreeFacts;
+            _cacheTransactionHandler = cacheTransactionHandler;
+            _command = command;
+        }
+
+        protected virtual bool IsQueryAlwaysCached()
+        {
+            return AlwaysCachedQueriesRegistrar.Instance.IsQueryCached(
+                _commandTreeFacts.MetadataWorkspace, _command.CommandText);
+        }
+
+        protected virtual bool IsQueryBlocked()
+        {
+            return BlockedQueriesRegistrar.Instance.IsQueryBlocked(
+                _commandTreeFacts.MetadataWorkspace, _command.CommandText);
+        }
+
+        public virtual bool IsCacheable()
+        {
+            return _commandTreeFacts.IsQuery &&
+                   (IsQueryAlwaysCached() ||
+                    !_commandTreeFacts.UsesNonDeterministicFunctions &&
+                    !IsQueryBlocked() &&
+                    _cachingPolicy.CanBeCached(_commandTreeFacts.AffectedEntitySets, _command.CommandText,
+                        _command.Parameters.Cast<DbParameter>()
+                            .Select(p => new KeyValuePair<string, object>(p.ParameterName, p.Value))));
+        }
+
+        public virtual string CreateKey()
+        {
+            return
+                string.Format(
+                    "{0}_{1}_{2}",
+                    _command.Connection.Database,
+                    _command.CommandText,
+                    string.Join(
+                        "_",
+                        _command.Parameters.Cast<DbParameter>()
+                            .Select(p => string.Format("{0}={1}", p.ParameterName, p.Value))));
+        }
+
+        public virtual bool GetCachedDbDataReader(string key, out DbDataReader dbDataReader)
+        {
+            CachedResults value;
+            if (_cacheTransactionHandler.GetItem(_command.Transaction, key, _command.Connection, out value))
+            {
+                dbDataReader = CreateDataReaderFromCachedResults(value);
+                return true;
+            }
+            dbDataReader = null;
+            return false;
+        }
+
+        public virtual DbDataReader SetCacheFromDbDataReader(string key, DbDataReader reader)
+        {
+            var queryResults = new List<object[]>();
+
+            while (reader.Read())
+            {
+                var values = new object[reader.FieldCount];
+                reader.GetValues(values);
+                queryResults.Add(values);
+            }
+
+            var cachedResults =
+                new CachedResults(
+                    GetTableMetadata(reader), queryResults, reader.RecordsAffected);
+
+            var cachedReader = CreateDataReaderFromCachedResults(cachedResults);
+
+            if (!ShouldSetCache(queryResults.Count)) return cachedReader;
+
+            SetCache(key, cachedResults);
+
+            return cachedReader;
+        }
+
+#if !NET40
+        public virtual async Task<DbDataReader> SetCacheFromDbDataReaderAsync(string key, DbDataReader reader, CancellationToken cancellationToken)
+        {
+            var queryResults = new List<object[]>();
+
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var values = new object[reader.FieldCount];
+                reader.GetValues(values);
+                queryResults.Add(values);
+            }
+
+            var cachedResults =
+                new CachedResults(
+                    GetTableMetadata(reader), queryResults, reader.RecordsAffected);
+
+            var cachedReader = CreateDataReaderFromCachedResults(cachedResults);
+
+            if (!ShouldSetCache(queryResults.Count)) return cachedReader;
+            
+            SetCache(key, cachedResults);
+            
+            return cachedReader;
+        }
+#endif
+
+        protected virtual DbDataReader CreateDataReaderFromCachedResults(CachedResults cachedResults)
+        {
+            return new CachingReader(cachedResults);
+        }
+
+        protected virtual bool ShouldSetCache(int queryResultCount)
+        {
+            int minCacheableRows, maxCachableRows;
+            _cachingPolicy.GetCacheableRows(_commandTreeFacts.AffectedEntitySets, out minCacheableRows,
+                out maxCachableRows);
+
+            return IsQueryAlwaysCached() ||
+                   (queryResultCount >= minCacheableRows && queryResultCount <= maxCachableRows);
+        }
+
+
+        protected virtual void SetCache<TObject>(string key, TObject cachedResults)
+        {
+            TimeSpan slidingExpiration;
+            DateTimeOffset absoluteExpiration;
+            _cachingPolicy.GetExpirationTimeout(_commandTreeFacts.AffectedEntitySets, out slidingExpiration,
+                out absoluteExpiration);
+
+            _cacheTransactionHandler.PutItem(
+                _command.Transaction,
+                key,
+                cachedResults,
+                _commandTreeFacts.AffectedEntitySets.Select(s => s.Name),
+                slidingExpiration,
+                absoluteExpiration,
+                _command.Connection);
+        }
+
+        private ColumnMetadata[] GetTableMetadata(DbDataReader reader)
+        {
+            var columnMetadata = new ColumnMetadata[reader.FieldCount];
+
+            for (var i = 0; i < reader.FieldCount; i++)
+            {
+                columnMetadata[i] =
+                    new ColumnMetadata(
+                        reader.GetName(i), reader.GetDataTypeName(i), reader.GetFieldType(i));
+            }
+
+            return columnMetadata;
+        }
+
+        public virtual bool GetCachedScalarObject(string key, out object cachedObject)
+        {
+            return _cacheTransactionHandler.GetItem(_command.Transaction, key, _command.Connection, out cachedObject);
+        }
+
+        public virtual void SetCacheFromScalarObject(string key, object value)
+        {
+            SetCache(key, value);
+        }
+
+        public virtual void InvalidateSets(int recordsAffected)
+        {
+            if (recordsAffected > 0 && _commandTreeFacts.AffectedEntitySets.Any())
+            {
+                _cacheTransactionHandler.InvalidateSets(_command.Transaction, 
+                    _commandTreeFacts.AffectedEntitySets.Select(s => s.Name),
+                    _command.Connection);
+            }
+        }
+    }
+}

--- a/src/EFCache/CachingReader.cs
+++ b/src/EFCache/CachingReader.cs
@@ -9,7 +9,7 @@ namespace EFCache
     using System.Data.Common;
     using System.Diagnostics;
 
-    internal class CachingReader : DbDataReader
+    public class CachingReader : DbDataReader
     {
         private enum State
         {
@@ -27,7 +27,7 @@ namespace EFCache
         // TODO: multiple resultsets?
         private readonly IEnumerator<object[]> _resultRowsEnumerator;
 
-        internal CachingReader(CachedResults cachedResults)
+        public CachingReader(CachedResults cachedResults)
         {
             Debug.Assert(cachedResults != null, "cachedResults is null");
 

--- a/src/EFCache/ColumnMetadata.cs
+++ b/src/EFCache/ColumnMetadata.cs
@@ -5,7 +5,7 @@ namespace EFCache
     using System.Runtime.Serialization;
 
     [Serializable]
-    internal struct ColumnMetadata : ISerializable
+    public struct ColumnMetadata : ISerializable
     {
         private readonly string _name;
         private readonly string _dataTypeName;

--- a/src/EFCache/CommandTreeFacts.cs
+++ b/src/EFCache/CommandTreeFacts.cs
@@ -11,7 +11,7 @@ namespace EFCache
     using System.Diagnostics;
     using System.Linq;
 
-    internal class CommandTreeFacts
+    internal class CommandTreeFacts : ICommandTreeFacts
     {
         private static readonly HashSet<string> NonDeterministicFunctions = new HashSet<string>(
             new[] {

--- a/src/EFCache/EntityFrameworkCache.cs
+++ b/src/EFCache/EntityFrameworkCache.cs
@@ -19,5 +19,16 @@ namespace EFCache
                     (dbServices, _) => new CachingProviderServices(dbServices, transactionHandler, cachingPolicy));
             DbInterception.Add(transactionHandler);
         }
+
+        public static void Initialize(ICacheProvider cache) => Initialize(cache, new CachingPolicy());
+        public static void Initialize(ICacheProvider cache, CachingPolicy cachingPolicy)
+        {
+            var transactionHandler = new CacheTransactionHandler(cache);
+
+            DbConfiguration.Loaded +=
+                (sender, args) => args.ReplaceService<DbProviderServices>(
+                    (dbServices, _) => new CachingProviderServices(dbServices, transactionHandler, cachingPolicy));
+            DbInterception.Add(transactionHandler);
+        }
     }
 }

--- a/src/EFCache/ICacheItemInvalidation.cs
+++ b/src/EFCache/ICacheItemInvalidation.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EFCache
+{
+    public interface ICacheItemInvalidation
+    {
+        /// <summary>
+        /// Invalidates cache entry with a given key.
+        /// </summary>
+        /// <param name="key">The cache key.</param>
+        void InvalidateItem(string key);
+    }
+}

--- a/src/EFCache/ICacheProvider.cs
+++ b/src/EFCache/ICacheProvider.cs
@@ -1,16 +1,12 @@
-﻿// Copyright (c) Pawel Kadluczka, Inc. All rights reserved. See License.txt in the project root for license information.
-
-// Created based on the ICache.cs from Tracing and Caching Provider Wrappers for Entity Framework sample to make it easy to port exisiting applications
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace EFCache
 {
-    using System;
-    using System.Collections.Generic;
-
-    /// <summary>
-    /// Interface to be implemented by cache implementations.
-    /// </summary>
-    public interface ICache
+    public interface ICacheProvider : ICache
     {
         /// <summary>
         /// Tries to the get cached entry by key.
@@ -18,7 +14,7 @@ namespace EFCache
         /// <param name="key">The cache key.</param>
         /// <param name="value">The retrieved value.</param>
         /// <returns>A value of <c>true</c> if entry was found in the cache, <c>false</c> otherwise.</returns>
-        bool GetItem(string key, out object value);
+        bool GetItem<TObject>(string key, out TObject value);
 
         /// <summary>
         /// Adds the specified entry to the cache.
@@ -28,12 +24,12 @@ namespace EFCache
         /// <param name="dependentEntitySets">The list of dependent entity sets.</param>
         /// <param name="slidingExpiration">The sliding expiration.</param>
         /// <param name="absoluteExpiration">The absolute expiration.</param>
-        void PutItem(string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration);
+        void PutItem<TObject>(string key, TObject value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration);
 
         /// <summary>
         /// Invalidates all cache entries which are dependent on any of the specified entity sets.
         /// </summary>
         /// <param name="entitySets">The entity sets.</param>
-        void InvalidateSets(IEnumerable<string> entitySets);
+        new void InvalidateSets(IEnumerable<string> entitySets);
     }
 }

--- a/src/EFCache/ICachingCommandStrategy.cs
+++ b/src/EFCache/ICachingCommandStrategy.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EFCache
+{
+    public interface ICachingCommandStrategy
+    {
+        bool IsCacheable();
+        void InvalidateSets(int resultRecordsAffected);
+        string CreateKey();
+        bool GetCachedDbDataReader(string key, out DbDataReader dbDataReader);
+        DbDataReader SetCacheFromDbDataReader(string key, DbDataReader reader);
+#if !NET40
+        Task<DbDataReader> SetCacheFromDbDataReaderAsync(string key, DbDataReader reader, CancellationToken cancellationToken);
+#endif
+        bool GetCachedScalarObject(string key, out object cachedObject);
+        void SetCacheFromScalarObject(string key, object value);
+    }
+}

--- a/src/EFCache/ICommandTreeFacts.cs
+++ b/src/EFCache/ICommandTreeFacts.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data.Entity.Core.Metadata.Edm;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EFCache
+{
+    public interface ICommandTreeFacts
+    {
+        bool IsQuery { get; }
+
+        bool UsesNonDeterministicFunctions { get; }
+
+        MetadataWorkspace MetadataWorkspace { get; }
+        ReadOnlyCollection<EntitySetBase> AffectedEntitySets { get; }
+    }
+}

--- a/test/EFCacheTests/CacheTransactionHandlerTests.cs
+++ b/test/EFCacheTests/CacheTransactionHandlerTests.cs
@@ -17,7 +17,7 @@ namespace EFCache
         {
             Assert.Equal(
                 "cache",
-                Assert.Throws<ArgumentNullException>(() => new CacheTransactionHandler(null)).ParamName);
+                Assert.Throws<ArgumentNullException>(() => new CacheTransactionHandler(cache:null)).ParamName);
         }
 
         [Fact]
@@ -128,8 +128,8 @@ namespace EFCache
         {
             var transactionHandler = new Mock<CacheTransactionHandler>{ CallBase = true }.Object;
 
-            Assert.Throws<InvalidOperationException>(() =>
-                transactionHandler.GetItem(null, "key", Mock.Of<DbConnection>(), out _));
+            Assert.ThrowsAny<InvalidOperationException>(() =>
+                transactionHandler.GetItem(null, "key", Mock.Of<DbConnection>(), out object _));
         }
 
         [Fact]
@@ -141,7 +141,7 @@ namespace EFCache
                 .Returns(Mock.Of<ICache>());
             var dbConnection = Mock.Of<DbConnection>();
 
-            mockTransactionHandler.Object.GetItem(null, "key", dbConnection, out _);
+            mockTransactionHandler.Object.GetItem(null, "key", dbConnection, out object _);
 
             mockTransactionHandler.Protected()
                 .Verify("ResolveCache", Times.Once(), dbConnection);


### PR DESCRIPTION
Motivation:
1. I'm using Easycaching.Redis as caching provider, and I'm getting the error in CachingReader class when trying to cast a DBNull value into a primitive type like string.
2. I want to change the CachedResult type into a more json/messagepack serializer friendly class.
3. I want to try using DataTable.CreateDataReader as the data reader instead of CachingReader.

I've tried to be backwards compatible.
Request you to accept this PR or provide any comments on improvement.

Thank you for creating this library. I'm open to contribute a small amount if you're okay with it.